### PR TITLE
Update demo for noetic

### DIFF
--- a/traj/config/demo.rviz
+++ b/traj/config/demo.rviz
@@ -1,0 +1,166 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 549
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base:
+          Value: true
+        base_link:
+          Value: true
+        flange:
+          Value: true
+        link_1:
+          Value: true
+        link_2:
+          Value: true
+        link_3:
+          Value: true
+        link_4:
+          Value: true
+        link_5:
+          Value: true
+        link_6:
+          Value: true
+        tool0:
+          Value: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base_link:
+          base:
+            {}
+          link_1:
+            link_2:
+              link_3:
+                link_4:
+                  link_5:
+                    link_6:
+                      flange:
+                        tool0:
+                          {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 3.8008627891540527
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: -0.055437419563531876
+        Y: -0.5335769057273865
+        Z: 0.5920925140380859
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4853982925415039
+      Target Frame: <Fixed Frame>
+      Yaw: 0.9103966951370239
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002b0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002eb00fffffffb0000000800540069006d0065010000000000000450000000000000000000000354000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 1027
+  Y: 329

--- a/traj/launch/include/load_demo_arm.launch.xml
+++ b/traj/launch/include/load_demo_arm.launch.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+    <param name="robot_description" command="$(find xacro)/xacro '$(find traj)/urdf/demo_arm.urdf.xacro'" />
+</launch>

--- a/traj/launch/sim_demo.launch
+++ b/traj/launch/sim_demo.launch
@@ -3,19 +3,17 @@
   <arg name="plot" default="false"/>
 
   <!-- Load robot model -->
-  <include file="$(find fanuc_m20ib_support)/launch/load_m20ib25.launch" />
+  <include file="$(find traj)/launch/include/load_demo_arm.launch.xml" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
-  <!-- industrial_robot_simulator: accepts robot commands and reports status -->
-  <rosparam param="controller_joint_names">['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']</rosparam>
-  <node pkg="industrial_robot_simulator" type="industrial_robot_simulator" name="industrial_robot_simulator"/>
-  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
+  <!--
+  <node name="dummy_joint_trajectory_server" pkg="traj" type="dummy_joint_trajectory_server" />-->
 
   <node pkg="traj" type="demo" name="traj_demo">
     <param name="plot" value="$(arg plot)"/>
     <param name="execute" value="true"/>
   </node>
 
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find traj)/config/demo.rviz" required="true" />
 
 </launch>

--- a/traj/package.xml
+++ b/traj/package.xml
@@ -10,7 +10,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>python-matplotlib</exec_depend>
-  <exec_depend>python-numpy</exec_depend>
-  <exec_depend>python-sympy</exec_depend>
+  <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-sympy</exec_depend>
+
+  <!-- Needed for launching the demo -->
+  <!-- <exec_depend>fanuc_m20ib_support</exec_depend> -->
+  <exec_depend>robot_state_publisher</exec_depend>
 </package>

--- a/traj/scripts/demo
+++ b/traj/scripts/demo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple example that parametrizes a 2d joint-space path.
 """
@@ -109,6 +109,10 @@ goal = create_joint_trajectory_goal(trajectory_position_function, joint_names, s
 if execute:
     follow_trajectory_client.send_goal(goal)
     follow_trajectory_client.wait_for_result()
+
+# Let rospy finish up before we turn the main thread over to matplotlib. This just
+# avoids warnings about dropped connections from other nodes.
+rospy.signal_shutdown()
 
 if plot:
     traj.plot.plot_trajectory(plt.figure(), trajectory_position_function, trajectory_velocity_function,

--- a/traj/scripts/discrete_demo
+++ b/traj/scripts/discrete_demo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import functools
 

--- a/traj/scripts/discrete_demo_1d
+++ b/traj/scripts/discrete_demo_1d
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import time
 
 from matplotlib import pyplot as plt

--- a/traj/scripts/dummy_joint_trajectory_server
+++ b/traj/scripts/dummy_joint_trajectory_server
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import actionlib
+import copy
+from control_msgs.msg import FollowJointTrajectoryAction, FollowJointTrajectoryGoal
+import numpy as np
+import rospy
+from sensor_msgs.msg import JointState
+import threading
+
+
+class Trajectory:
+    def __init__(self, joint_names, times, positions, velocities=None, accelerations=None):
+        self.joint_names = joint_names
+        self.times = times
+        self.positions = positions
+        self.velocities = velocities
+        self.accelerations = accelerations
+
+    @staticmethod
+    def from_message(trajectory_message):
+        times = np.array([p.time_from_start.to_sec() for p in trajectory_message.points])
+        positions = np.array([p.positions for p in trajectory_message.points])
+        return Trajectory(trajectory_message.joint_names, times, positions)
+
+    def get_all_joint_positions(self, time_from_start):
+        return np.array(
+            [self.get_joint_position(joint_i, time_from_start) for joint_i in range(
+                len(self.joint_names))])
+
+    def get_joint_position(self, joint_i, time_from_start):
+        # TODO (maybe): Use cubic interpolation if we know velocities.
+        return np.interp(time_from_start, self.times, self.positions[:, joint_i])
+
+
+class DummyJointTrajectoryServer:
+    def __init__(self):
+        self._num_joints = 6
+        self._joint_names = ['joint_{}'.format(n) for n in range(1, self._num_joints + 1)]
+        self._joint_positions = np.zeros((self._num_joints,))
+
+        # Currently executing trajectory.
+        self._current_trajectory = None
+        self._current_trajectory_start_time = None
+        self._current_trajectory_complete = False
+        self._current_trajectory_lock = threading.Lock()
+
+        self._joint_state_publisher = rospy.Publisher('joint_states', JointState, queue_size=100)
+        self._action_server = actionlib.SimpleActionServer(
+            'joint_trajectory_action', FollowJointTrajectoryAction, self.execute_joint_trajectory,
+            auto_start=False)
+
+        # Start everything.
+        self._action_server.start()
+        self._joint_state_pub_timer = rospy.Timer(rospy.Duration(0.01), self.update_joint_state)
+
+    def update_joint_state(self, _):
+        t = rospy.Time.now()
+
+        # If we're simulating a trajectory, interpolate the joint state from it.
+        with self._current_trajectory_lock:
+            if self._current_trajectory is not None:
+                time_from_start = (t - self._current_trajectory_start_time).to_sec()
+                self._joint_positions = self._current_trajectory.get_all_joint_positions(time_from_start)
+                if time_from_start >= self._current_trajectory.times[-1]:
+                    self._current_trajectory_complete = True
+
+        # Publish the current joint state.
+        joint_state_message = JointState()
+        joint_state_message.header.stamp = t
+        joint_state_message.name = copy.copy(self._joint_names)
+        joint_state_message.position = list(self._joint_positions)
+        self._joint_state_publisher.publish(joint_state_message)
+
+    def execute_joint_trajectory(self, joint_trajectory_goal):
+        with self._current_trajectory_lock:
+            self._current_trajectory = Trajectory.from_message(joint_trajectory_goal.trajectory)
+            self._current_trajectory_start_time = rospy.Time.now()
+            self._current_trajectory_complete = False
+
+        poll_for_completion_rate = rospy.Rate(100)
+        while True:
+            if rospy.is_shutdown():
+                self._action_server.set_failed()
+                break
+
+            if self._action_server.is_preempt_requested():
+                self._action_server.set_preempted()
+                break
+
+            with self._current_trajectory_lock:
+                if self._current_trajectory_complete:
+                    self._action_server.set_succeeded()
+                    break
+
+            poll_for_completion_rate.sleep()
+
+def main():
+    rospy.init_node('dummy_joint_trajectory_server')
+    server = DummyJointTrajectoryServer()
+    rospy.spin()
+
+if __name__ == '__main__':
+    main()

--- a/traj/scripts/example_toppra_s_variable
+++ b/traj/scripts/example_toppra_s_variable
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple example that parametrizes a 2d joint-space path.
 """

--- a/traj/scripts/example_toppra_time_domain.py
+++ b/traj/scripts/example_toppra_time_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import math
 import traj 
 from matplotlib import pyplot as plt

--- a/traj/scripts/parameterize_path_example
+++ b/traj/scripts/parameterize_path_example
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple example that parametrizes a 2d joint-space path.
 """

--- a/traj/scripts/plot_bag
+++ b/traj/scripts/plot_bag
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 
 from matplotlib import pyplot as plt

--- a/traj/scripts/seven_segment_example
+++ b/traj/scripts/seven_segment_example
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple example that computes a seven segment motion profile a 1d motion with given start and
 end positions. Start and end velocity/acceleration/jerk are assumed to be zero.

--- a/traj/scripts/synchronized_segment_example.py
+++ b/traj/scripts/synchronized_segment_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 example for the joint motion synchronization algorithm 
 '''

--- a/traj/scripts/synchronized_traj_example.py
+++ b/traj/scripts/synchronized_traj_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 example to check the joint motion synchronization algorithm [full trajectory] 
 '''

--- a/traj/scripts/traj_segment_example
+++ b/traj/scripts/traj_segment_example
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple example that fits general trajectory segment, given the start and
 end positions/velocities. Start and end acceleration/jerk are assumed to be zero.

--- a/traj/src/traj/trajectory.py
+++ b/traj/src/traj/trajectory.py
@@ -67,9 +67,9 @@ def trajectory_for_path(path, max_velocities, max_accelerations, max_jerks):
         # Substitute time profile for s into the path function to get trajectory as a function of t.
         for function_i in range(len(s_position.functions)):
             position_vs_t = fsegment.subs(s, s_position.functions[function_i])
-            velocity_vs_t = diff(position_vs_t)
-            acceleration_vs_t = diff(velocity_vs_t)
-            jerk_vs_t = diff(acceleration_vs_t)
+            velocity_vs_t = diff(position_vs_t, t)
+            acceleration_vs_t = diff(velocity_vs_t, t)
+            jerk_vs_t = diff(acceleration_vs_t, t)
             trajectory_position_functions.append(position_vs_t)
             trajectory_velocity_functions.append(velocity_vs_t)
             trajectory_acceleration_functions.append(acceleration_vs_t)

--- a/traj/urdf/demo_arm.urdf.xacro
+++ b/traj/urdf/demo_arm.urdf.xacro
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<robot name="demo_arm" xmlns:xacro="http://wiki.ros.org/xacro">
+    <!-- links: main serial chain -->
+    <link name="base_link"/>
+    <link name="link_1"/>
+    <link name="link_2"/>
+    <link name="link_3"/>
+    <link name="link_4"/>
+    <link name="link_5"/>
+    <link name="link_6"/>
+
+    <!-- joints: main serial chain -->
+    <joint name="joint_1" type="revolute">
+        <origin xyz="0 0 0.650" rpy="0 0 0"/>
+        <parent link="base_link"/>
+        <child link="link_1"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="${radians(-180)}" upper="${radians(180)}" effort="0" velocity="${radians(205)}" />
+    </joint>
+    <joint name="joint_2" type="revolute">
+        <origin xyz="0.075 0 0" rpy="0 0 0"/>
+        <parent link="link_1"/>
+        <child link="link_2"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="${radians(-100)}" upper="${radians(140)}" effort="0" velocity="${radians(205)}" />
+    </joint>
+    <joint name="joint_3" type="revolute">
+        <origin xyz="0 0 0.905" rpy="0 0 0"/>
+        <parent link="link_2"/>
+        <child link="link_3"/>
+        <axis xyz="0 -1 0"/>
+        <limit lower="${radians(-149)}" upper="${radians(320)}" effort="0" velocity="${radians(260)}" />
+    </joint>
+    <joint name="joint_4" type="revolute">
+        <origin xyz="0 0 0.120" rpy="0 0 0"/>
+        <parent link="link_3"/>
+        <child link="link_4"/>
+        <axis xyz="-1 0 0"/>
+        <limit lower="${radians(-200)}" upper="${radians(200)}" effort="0" velocity="${radians(415)}" />
+    </joint>
+    <joint name="joint_5" type="revolute">
+        <origin xyz="0.865 0 0" rpy="0 0 0"/>
+        <parent link="link_4"/>
+        <child link="link_5"/>
+        <axis xyz="0 -1 0"/>
+        <limit lower="${radians(-145)}" upper="${radians(145)}" effort="0" velocity="${radians(415)}" />
+    </joint>
+    <joint name="joint_6" type="revolute">
+        <origin xyz="0.100 0 0" rpy="0 0 0"/>
+        <parent link="link_5"/>
+        <child link="link_6"/>
+        <axis xyz="-1 0 0"/>
+        <limit lower="${radians(-270)}" upper="${radians(270)}" effort="0" velocity="${radians(880)}" />
+    </joint>
+
+    <!-- ROS-Industrial 'base' frame: base_link to Fanuc World Coordinates transform -->
+    <link name="base" />
+    <joint name="base_link-base" type="fixed">
+        <origin xyz="0 0 0.650" rpy="0 0 0"/>
+        <parent link="base_link"/>
+        <child link="base"/>
+    </joint>
+
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="flange" />
+    <joint name="joint_6-flange" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <parent link="link_6" />
+        <child link="flange" />
+    </joint>
+
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
+    <link name="tool0" />
+    <joint name="link_6-tool0" type="fixed">
+        <origin xyz="0 0 0" rpy="${pi} ${-pi/2.0} 0" />
+        <parent link="flange" />
+        <child link="tool0" />
+    </joint>
+</robot>


### PR DESCRIPTION
Shebangs and dependencies now use python3, although all code is still
compatible with python2. Fanuc support package hasn't been released into
noetic, so a simplified URDF has been added to this package to use for
demos. industrial_core hasn't been released for noetic (and probably
won't be for a while), so I've added a python script to replace the
indsutrial robot simulator.

I'd like to eventually have master be as compatible as possible with both melodic and noetic.

Note: I still need to make an upstream PR to add a python3-sympy rule to rosdep.